### PR TITLE
Fix broken image tags

### DIFF
--- a/src/components/dashboard/PostcardItem.jsx
+++ b/src/components/dashboard/PostcardItem.jsx
@@ -34,7 +34,7 @@ import React from 'react';
             <CardHeader className="pb-2">
               <div className="aspect-[3/2] bg-muted rounded-md mb-3 flex items-center justify-center overflow-hidden">
                 {postcard.rendered_image_url ? (
-                  <img-replace src={postcard.rendered_image_url} alt={postcard.title || 'Postkarte'} className="object-cover w-full h-full" />
+                  <img src={postcard.rendered_image_url} alt={postcard.title || 'Postkarte'} className="object-cover w-full h-full" />
                 ) : (
                   <div className="text-muted-foreground flex flex-col items-center">
                     <ImageIcon size={48} />

--- a/src/components/dashboard/ProfileOverview.jsx
+++ b/src/components/dashboard/ProfileOverview.jsx
@@ -169,7 +169,7 @@ import React, { useEffect, useState } from 'react';
                   </div>
                   {profile?.avatar_url && (
                     <div className="flex items-center space-x-3 p-3 bg-muted/30 rounded-md">
-                       <img-replace src={profile.avatar_url} alt="Avatar" className="h-10 w-10 rounded-full object-cover border-2 border-primary" />
+                       <img src={profile.avatar_url} alt="Avatar" className="h-10 w-10 rounded-full object-cover border-2 border-primary" />
                        <span>Avatar</span>
                     </div>
                   )}


### PR DESCRIPTION
## Summary
- fix `<img-replace>` typo in `PostcardItem` and `ProfileOverview`

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68441fb393cc832c99c14a9a296d2bc6