### PR TITLE
Add photo style upload page

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -9,6 +9,7 @@ import PostcardEditorPage from '@/pages/PostcardEditorPage';
 import PostcardDetailPage from '@/pages/PostcardDetailPage';
 import SharePage from '@/pages/SharePage';
 import ImageGeneratorPage from '@/pages/ImageGeneratorPage';
+import PhotoStylePage from '@/pages/PhotoStylePage';
     import { Button } from '@/components/ui/button'; // Added import for Button
     
     import { Toaster } from '@/components/ui/toaster';
@@ -75,6 +76,7 @@ import ImageGeneratorPage from '@/pages/ImageGeneratorPage';
               <Route path="editor" element={<PostcardEditorPage />} />
               <Route path="editor/:postcardId" element={<PostcardEditorPage />} />
               <Route path="generator" element={<ImageGeneratorPage />} />
+              <Route path="photo-style" element={<PhotoStylePage />} />
             </Route>
             <Route path="/share/:shareToken" element={<SharePage />} /> 
             <Route path="/" element={<Navigate to={session ? "/dashboard/my-postcards" : "/login"} />} />

--- a/src/pages/DashboardPage.jsx
+++ b/src/pages/DashboardPage.jsx
@@ -4,7 +4,7 @@ import React, { useState, useEffect } from 'react';
     import { supabase } from '@/lib/supabaseClient';
     import { useToast } from '@/components/ui/use-toast';
     import { motion, AnimatePresence } from 'framer-motion';
-import { LogOut, LayoutDashboard, Image as ImageIcon, Users, UserCircle, PlusCircle, Menu, X as CloseIcon, PanelLeftClose, PanelRightClose, Wand2 } from 'lucide-react';
+import { LogOut, LayoutDashboard, Image as ImageIcon, Users, UserCircle, PlusCircle, Menu, X as CloseIcon, PanelLeftClose, PanelRightClose, Wand2, Palette } from 'lucide-react';
     import { cn } from '@/lib/utils';
 
     const DashboardPage = () => {
@@ -39,6 +39,7 @@ import { LogOut, LayoutDashboard, Image as ImageIcon, Users, UserCircle, PlusCir
         { name: 'Meine Postkarten', path: '/dashboard/my-postcards', icon: ImageIcon },
         { name: 'Öffentliche Galerie', path: '/dashboard/gallery', icon: Users },
         { name: 'Bildgenerator', path: '/dashboard/generator', icon: Wand2 },
+        { name: 'Foto Styler', path: '/dashboard/photo-style', icon: Palette },
       ];
 
       useEffect(() => {

--- a/src/pages/PhotoStylePage.jsx
+++ b/src/pages/PhotoStylePage.jsx
@@ -1,0 +1,84 @@
+import React, { useState } from 'react';
+import { Input } from '@/components/ui/input';
+import { Button } from '@/components/ui/button';
+import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from '@/components/ui/select';
+import { useToast } from '@/components/ui/use-toast';
+
+const styles = [
+  { label: 'Ölgemälde', value: 'oil painting' },
+  { label: 'Cartoon', value: 'cartoon' },
+  { label: 'Skizze', value: 'sketch' }
+];
+
+const PhotoStylePage = () => {
+  const [file, setFile] = useState(null);
+  const [previewUrl, setPreviewUrl] = useState('');
+  const [style, setStyle] = useState(styles[0].value);
+  const [generatedUrl, setGeneratedUrl] = useState('');
+  const [loading, setLoading] = useState(false);
+  const { toast } = useToast();
+
+  const handleFileChange = (e) => {
+    const selected = e.target.files[0];
+    if (selected) {
+      setFile(selected);
+      setPreviewUrl(URL.createObjectURL(selected));
+      setGeneratedUrl('');
+    }
+  };
+
+  const handleGenerate = async () => {
+    if (!file) {
+      toast({ title: 'Kein Foto ausgewählt', variant: 'destructive' });
+      return;
+    }
+    setLoading(true);
+    try {
+      const formData = new FormData();
+      formData.append('image', file);
+      formData.append('prompt', `Apply ${style} style`);
+      formData.append('n', 1);
+      formData.append('size', '1024x1024');
+
+      const res = await fetch('https://api.openai.com/v1/images/variations', {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${import.meta.env.VITE_OPENAI_API_KEY}`
+        },
+        body: formData
+      });
+      const data = await res.json();
+      setGeneratedUrl(data.data?.[0]?.url || '');
+    } catch (err) {
+      toast({ title: 'Fehler bei der Bildgenerierung', description: err.message, variant: 'destructive' });
+    }
+    setLoading(false);
+  };
+
+  return (
+    <div className="min-h-screen flex flex-col items-center justify-center bg-background p-4 space-y-4">
+      <div className="w-full max-w-xl space-y-4">
+        <Input type="file" accept="image/*" onChange={handleFileChange} />
+        {previewUrl && <img src={previewUrl} alt="Preview" className="w-full h-auto rounded" />}
+        <Select value={style} onValueChange={setStyle}>
+          <SelectTrigger>
+            <SelectValue placeholder="Stil wählen" />
+          </SelectTrigger>
+          <SelectContent>
+            {styles.map((s) => (
+              <SelectItem key={s.value} value={s.value}>{s.label}</SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+        <Button onClick={handleGenerate} disabled={loading} className="w-full">
+          {loading ? 'Generiere...' : 'Style generieren'}
+        </Button>
+        {generatedUrl && (
+          <img src={generatedUrl} alt="Generated" className="w-full h-auto mt-4 rounded" />
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default PhotoStylePage;


### PR DESCRIPTION
## Summary
- create `PhotoStylePage` to upload a photo and generate a styled variation via the OpenAI API
- link the new page in routes and sidebar navigation

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_684433d0122c832ca7c6d5cfe2b3eb02