### PR TITLE
Refactor OpenAI API usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Dies ist eine Web-Anwendung zur Erstellung, Verwaltung und zum Teilen digitaler 
         # .env
         VITE_SUPABASE_URL=DEINE_SUPABASE_PROJEKT_URL
         VITE_SUPABASE_ANON_KEY=DEIN_SUPABASE_ANON_KEY
+        VITE_OPENAI_API_KEY=DEIN_OPENAI_API_KEY
         ```
 
 5.  **Supabase Datenbank-Schema:**

--- a/src/lib/openaiClient.js
+++ b/src/lib/openaiClient.js
@@ -1,0 +1,25 @@
+const API_URL = 'https://api.openai.com/v1/images/variations';
+
+export async function createImageVariation({ file, prompt, n = 1, size = '1024x1024' }) {
+  const formData = new FormData();
+  formData.append('image', file);
+  formData.append('prompt', prompt);
+  formData.append('n', n);
+  formData.append('size', size);
+
+  const res = await fetch(API_URL, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${import.meta.env.VITE_OPENAI_API_KEY}`
+    },
+    body: formData
+  });
+
+  if (!res.ok) {
+    const message = await res.text();
+    throw new Error(message);
+  }
+
+  const data = await res.json();
+  return data.data?.[0]?.url || '';
+}

--- a/src/pages/ImageGeneratorPage.jsx
+++ b/src/pages/ImageGeneratorPage.jsx
@@ -3,6 +3,7 @@ import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
 import { useToast } from '@/components/ui/use-toast';
 import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from '@/components/ui/select';
+import { createImageVariation } from '@/lib/openaiClient';
 
 const postcardSizes = [
   { label: 'A6 (105 x 148 mm)', value: '105x148' },
@@ -36,21 +37,13 @@ const ImageGeneratorPage = () => {
     }
     setLoading(true);
     try {
-      const formData = new FormData();
-      formData.append('image', file);
-      formData.append('prompt', `Apply ${style} style`);
-      formData.append('n', 1);
-      formData.append('size', size);
-
-      const res = await fetch('https://api.openai.com/v1/images/variations', {
-        method: 'POST',
-        headers: {
-          Authorization: `Bearer ${import.meta.env.VITE_OPENAI_API_KEY}`
-        },
-        body: formData
+      const url = await createImageVariation({
+        file,
+        prompt: `Apply ${style} style`,
+        n: 1,
+        size
       });
-      const data = await res.json();
-      setGeneratedUrl(data.data?.[0]?.url || '');
+      setGeneratedUrl(url);
     } catch (err) {
       toast({ title: 'Fehler bei der Bildgenerierung', description: err.message, variant: 'destructive' });
     }

--- a/src/pages/PhotoStylePage.jsx
+++ b/src/pages/PhotoStylePage.jsx
@@ -3,6 +3,7 @@ import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
 import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from '@/components/ui/select';
 import { useToast } from '@/components/ui/use-toast';
+import { createImageVariation } from '@/lib/openaiClient';
 
 const styles = [
   { label: 'Ölgemälde', value: 'oil painting' },
@@ -35,21 +36,12 @@ const PhotoStylePage = () => {
     }
     setLoading(true);
     try {
-      const formData = new FormData();
-      formData.append('image', file);
-      formData.append('prompt', `Apply ${style} style`);
-      formData.append('n', 1);
-      formData.append('size', '1024x1024');
-
-      const res = await fetch('https://api.openai.com/v1/images/variations', {
-        method: 'POST',
-        headers: {
-          Authorization: `Bearer ${import.meta.env.VITE_OPENAI_API_KEY}`
-        },
-        body: formData
+      const url = await createImageVariation({
+        file,
+        prompt: `Apply ${style} style`,
+        n: 1
       });
-      const data = await res.json();
-      setGeneratedUrl(data.data?.[0]?.url || '');
+      setGeneratedUrl(url);
     } catch (err) {
       toast({ title: 'Fehler bei der Bildgenerierung', description: err.message, variant: 'destructive' });
     }


### PR DESCRIPTION
## Summary
- centralize OpenAI API calls in `openaiClient`
- update photo style and image generator pages to use the new helper
- document `VITE_OPENAI_API_KEY` in README

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68443ed10448832c866bd4e7aae32a08